### PR TITLE
Modernize UI with green theme

### DIFF
--- a/AIvy/AIvyApp.swift
+++ b/AIvy/AIvyApp.swift
@@ -13,6 +13,7 @@ struct AIvyApp: App {
     var body: some Scene {
         WindowGroup {
             AppRootView()
+                .tint(.phthaloGreen)
         }
     }
 }

--- a/AIvy/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/AIvy/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,7 +1,16 @@
 {
   "colors" : [
     {
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0",
+          "green" : "0.545",
+          "blue" : "0.447",
+          "alpha" : "1.0"
+        }
+      }
     }
   ],
   "info" : {

--- a/AIvy/Color+Custom.swift
+++ b/AIvy/Color+Custom.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+extension Color {
+    static let phthaloGreen = Color(red: 0/255, green: 139/255, blue: 114/255)
+}

--- a/AIvy/View/AppRootView.swift
+++ b/AIvy/View/AppRootView.swift
@@ -11,15 +11,18 @@ struct AppRootView: View {
     @Bindable private var coordinator = Coordinator()
 
     var body: some View {
-        Group {
-            switch coordinator.screen {
-            case .login:
-                LoginView(coordinator: coordinator)
-            case .register:
-                RegisterView(coordinator: coordinator)
-            case .chat:
-                ChatView(coordinator: coordinator)
+        NavigationStack {
+            Group {
+                switch coordinator.screen {
+                case .login:
+                    LoginView(coordinator: coordinator)
+                case .register:
+                    RegisterView(coordinator: coordinator)
+                case .chat:
+                    ChatView(coordinator: coordinator)
+                }
             }
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }

--- a/AIvy/View/ChatView.swift
+++ b/AIvy/View/ChatView.swift
@@ -11,41 +11,51 @@ struct ChatView: View {
     @Bindable var viewModel = ChatViewModel()
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             List(viewModel.messages, id: \.id) { message in
-                HStack {
+                HStack(alignment: .top) {
                     if message.sender == "AI" {
                         Text(message.content)
-                            .padding()
-                            .background(Color.gray.opacity(0.2))
-                            .cornerRadius(12)
-                    } else {
-                        Text(message.content)
-                            .padding()
-                            .background(Color.blue.opacity(0.2))
+                            .padding(10)
+                            .background(Color(.secondarySystemBackground))
                             .cornerRadius(12)
                         Spacer()
+                    } else {
+                        Spacer()
+                        Text(message.content)
+                            .padding(10)
+                            .background(Color.phthaloGreen.opacity(0.2))
+                            .cornerRadius(12)
                     }
                 }
+                .listRowSeparator(.hidden)
             }
-            
-            TextField("Write your message...", text: $viewModel.inputText)
-                .textFieldStyle(.roundedBorder)
-            
-            Button("Send") {
-                guard let userID = coordinator.currentUser?.id else { return }
-                    
-                Task {
-                    await viewModel.sendMessage(userID: userID)
+            .listStyle(.plain)
+
+            HStack {
+                TextField("Write your message...", text: $viewModel.inputText)
+                    .textFieldStyle(.roundedBorder)
+
+                Button(action: {
+                    guard let userID = coordinator.currentUser?.id else { return }
+                    Task { await viewModel.sendMessage(userID: userID) }
+                }) {
+                    Image(systemName: "paperplane.fill")
+                        .padding(8)
+                        .background(Color.phthaloGreen)
+                        .foregroundColor(.white)
+                        .clipShape(Circle())
                 }
+                .disabled(viewModel.inputText.trimmingCharacters(in: .whitespaces).isEmpty)
             }
-            
-            Button("Logout") {
-                coordinator.logout()
-            }
-            .foregroundColor(.red)
+            .padding()
         }
-        .padding()
+        .navigationTitle("Chat")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Logout") { coordinator.logout() }
+            }
+        }
         .task {
             if let userID = coordinator.currentUser?.id {
                 await viewModel.loadHistory(userID: userID)

--- a/AIvy/View/LoginView.swift
+++ b/AIvy/View/LoginView.swift
@@ -14,29 +14,38 @@ struct LoginView: View {
     @State private var password = ""
 
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             Text("Sign In")
-                .font(.title2).bold()
+                .font(.largeTitle.bold())
+                .padding(.bottom, 20)
 
             TextField("Email", text: $email)
-                .autocapitalization(.none)
-                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(12)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(10)
 
             SecureField("Password", text: $password)
-                .textFieldStyle(.roundedBorder)
+                .padding(12)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(10)
 
-            Button("Sign In") {
-                Task {
-                    await viewModel.login(email: email, password: password, coordinator: coordinator)
-                }
+            Button(action: {
+                Task { await viewModel.login(email: email, password: password, coordinator: coordinator) }
+            }) {
+                Text("Sign In")
+                    .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .tint(.phthaloGreen)
             .disabled(email.isEmpty || password.isEmpty)
 
             Button("No account? Register") {
                 coordinator.showRegister()
             }
             .font(.footnote)
+            .tint(.phthaloGreen)
 
             if let info = viewModel.infoMessage {
                 Text(info)

--- a/AIvy/View/RegisterView.swift
+++ b/AIvy/View/RegisterView.swift
@@ -14,30 +14,38 @@ struct RegisterView: View {
     @State private var password = ""
 
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             Text("Register")
-                .font(.title2).bold()
+                .font(.largeTitle.bold())
+                .padding(.bottom, 20)
 
             TextField("Email", text: $email)
-                .autocapitalization(.none)
-                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding(12)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(10)
 
             SecureField("Password", text: $password)
-                .textFieldStyle(.roundedBorder)
-                .padding(.horizontal)
+                .padding(12)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(10)
 
-            Button("Register") {
-                Task {
-                    await viewModel.register(email: email, password: password, coordinator: coordinator)
-                }
+            Button(action: {
+                Task { await viewModel.register(email: email, password: password, coordinator: coordinator) }
+            }) {
+                Text("Register")
+                    .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
+            .tint(.phthaloGreen)
             .disabled(email.isEmpty || password.isEmpty)
 
             Button("Already have an account? Sign In") {
                 coordinator.showLogin()
             }
             .font(.footnote)
+            .tint(.phthaloGreen)
 
             if let info = viewModel.infoMessage {
                 Text(info)


### PR DESCRIPTION
## Summary
- add phthalo green color extension and accent color
- wrap main view in `NavigationStack`
- restyle login, register and chat screens
- tint entire app with new color

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687a04c768ec8323bb17a0e547aa03ef